### PR TITLE
HOTFIX: Add missing server.baseUrl to config

### DIFF
--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -9,6 +9,9 @@ const config = {
   // Server Configuration
   port: process.env.PORT || 9002,
   nodeEnv: process.env.NODE_ENV || 'development',
+  server: {
+    baseUrl: process.env.API_BASE_URL || 'http://localhost:9002'
+  },
   
   // JWT Configuration
   jwt: {


### PR DESCRIPTION
## Critical Production Fix

This hotfix resolves the Railway production crash.

## Problem
- OAuth configuration expects `config.server.baseUrl` 
- The config object was missing the `server` property
- This caused: `TypeError: Cannot read properties of undefined (reading 'baseUrl')`

## Solution
- Added `server` object to config with `baseUrl` property
- Uses `API_BASE_URL` environment variable (already added to Railway)

## Test plan
- [ ] Merge directly to main (critical production fix)
- [ ] Railway will auto-deploy
- [ ] Verify https://novara-mvp-production.up.railway.app/api/health returns 200

🤖 Generated with [Claude Code](https://claude.ai/code)