### PR TITLE
HOTFIX: Use dynamic PORT for server.baseUrl

### DIFF
--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -10,7 +10,7 @@ const config = {
   port: process.env.PORT || 9002,
   nodeEnv: process.env.NODE_ENV || 'development',
   server: {
-    baseUrl: process.env.API_BASE_URL || 'http://localhost:9002'
+    baseUrl: process.env.API_BASE_URL || `http://localhost:${process.env.PORT || 9002}`
   },
   
   // JWT Configuration


### PR DESCRIPTION
## Fix for Railway Dynamic Port Issue

Fixes the bug identified in PR #13 comments.

## Problem
- Railway provides a dynamic PORT via `process.env.PORT`
- The fallback was hardcoded to port 9002
- This caused OAuth redirects to fail

## Solution
- Changed fallback from hardcoded `http://localhost:9002`
- To dynamic `http://localhost:${process.env.PORT || 9002}`
- Now correctly uses Railway's dynamic port

## Note
Production should use `API_BASE_URL` environment variable anyway, so this mainly affects the fallback behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)